### PR TITLE
Add DAG load balancing support

### DIFF
--- a/broctl/lb_pf_ring.py
+++ b/broctl/lb_pf_ring.py
@@ -74,6 +74,10 @@ class LBPFRing(BroControl.plugin.Plugin):
                 nn.env_vars.setdefault("PCAP_PF_RING_DNA_RSS", "1")
                 nn.interface = "%s@%d" % (nn.interface, app_instance)
 
+            elif nn.interface.startswith("pf_ring::dag:"):
+                # For the case where a user is running dag HLB
+                nn.interface = "%s@%d" % (nn.interface, app_instance*2)
+
             else:
                 nn.env_vars.setdefault("PCAP_PF_RING_CLUSTER_ID", dd[nn.host][nn.interface])
 


### PR DESCRIPTION
When using the pf_ring plugin for bro, support Endace DAG hardware load balancing

E.g. for 2-tuple load balancing to 8 streams on dag0 run:

dagconfig -d0 hash_tuple=2 hash_bins=8

In node.cfg:

[worker-1]
type=worker
host=localhost
interface=pf_ring::dag:0
lb_method=pf_ring
lb_procs=8

This would start 8 workers on dag0:0, dag0:2, ... , dag0:14

Note that the PFRINGClusterType is ignored in this case; set the tuple mode as above.